### PR TITLE
Issue-30: Actions of initial state are not executed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.oxo42</groupId>
     <artifactId>stateless4j</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>stateless4j</name>
     <parent>

--- a/src/main/java/com/github/oxo42/stateless4j/OutVar.java
+++ b/src/main/java/com/github/oxo42/stateless4j/OutVar.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2014 Fabien Renaud.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.github.oxo42.stateless4j;
 
 public final class OutVar<T> {

--- a/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
@@ -66,6 +66,10 @@ public class StateMachine<S, T> {
                 reference.setState(s);
             }
         };
+        if (config.isEntryActionOfInitialStateEnabled()) {
+            Transition<S,T> initialTransition = new Transition(initialState, initialState, null);
+            getCurrentRepresentation().enter(initialTransition);
+        }
     }
 
     /**
@@ -84,6 +88,10 @@ public class StateMachine<S, T> {
 
     public StateConfiguration<S, T> configure(S state) {
         return config.configure(state);
+    }
+    
+    public StateMachineConfig<S, T> configuration() {
+        return config;
     }
 
     /**
@@ -259,5 +267,4 @@ public class StateMachine<S, T> {
                 getState(),
                 params.toString());
     }
-
 }

--- a/src/main/java/com/github/oxo42/stateless4j/StateMachineConfig.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateMachineConfig.java
@@ -23,7 +23,45 @@ public class StateMachineConfig<TState,TTrigger> {
 
     private final Map<TState, StateRepresentation<TState, TTrigger>> stateConfiguration = new HashMap<>();
     private final Map<TTrigger, TriggerWithParameters<TState, TTrigger>> triggerConfiguration = new HashMap<>();
+    /**
+     * Added in 2.5.2.
+     * Default MUST be false for backward compatibility reasons. Prior to 2.5.2,
+     * entering the initial state never fires its entry action.
+     */
+    private boolean entryActionOfInitialStateEnabled = false;
 
+    /**
+     * Gets whether the entry action of the initial state of the state machine
+     * must be executed when the state machine starts.
+     * Default is false for backward compatibility sake.
+     * 
+     * Added in 2.5.2
+     *
+     * @return true if the entry action of the initial state of the state machine
+     * must be executed when the state machine starts.
+     */
+    public boolean isEntryActionOfInitialStateEnabled() {
+        return entryActionOfInitialStateEnabled;
+    }
+    
+    /**
+     * Enables the state machine to execute the entry action of the initial state
+     * when the state machine starts.
+     * This configuration is disabled by default.
+     */
+    public void enableEntryActionOfInitialState() {
+        this.entryActionOfInitialStateEnabled = true;
+    }
+    
+    /**
+     * Disables the state machine to execute the entry action of the initial state
+     * when the state machine starts.
+     * This is the default.
+     */
+    public void disableEntryActionOfInitialState() {
+        this.entryActionOfInitialStateEnabled = true;
+    }
+    
     /**
      * Return StateRepresentation for the specified state. May return null.
      *

--- a/src/main/java/com/github/oxo42/stateless4j/delegates/FuncBoolean.java
+++ b/src/main/java/com/github/oxo42/stateless4j/delegates/FuncBoolean.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2014 Fabien Renaud.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.github.oxo42.stateless4j.delegates;
 
 public interface FuncBoolean {

--- a/src/test/java/com/github/oxo42/stateless4j/InitialStateTests.java
+++ b/src/test/java/com/github/oxo42/stateless4j/InitialStateTests.java
@@ -1,0 +1,48 @@
+package com.github.oxo42.stateless4j;
+
+import com.github.oxo42.stateless4j.delegates.Action;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class InitialStateTests {
+
+    private boolean executed = false;
+
+    @Test
+    public void testInitialStateEntryActionNotExecuted() {
+        final State initial = State.B;
+        
+        StateMachineConfig<State, Trigger> config = config(initial);
+        
+        StateMachine<State, Trigger> sm = new StateMachine<>(initial, config);
+        assertEquals(initial, sm.getState());
+        assertFalse(executed);
+    }
+
+    @Test
+    public void testInitialStateEntryActionExecuted() {
+        final State initial = State.B;
+        
+        StateMachineConfig<State, Trigger> config = config(initial);
+        config.enableEntryActionOfInitialState();
+        
+        StateMachine<State, Trigger> sm = new StateMachine<>(initial, config);
+        assertEquals(initial, sm.getState());
+        assertTrue(executed);
+    }
+
+    private StateMachineConfig<State, Trigger> config(final State initial) {
+        StateMachineConfig<State, Trigger> config = new StateMachineConfig<>();
+        config.configure(initial)
+                .onEntry(new Action() {
+
+                    @Override
+                    public void doIt() {
+                        executed = true;
+                    }
+                });
+        return config;
+    }
+}


### PR DESCRIPTION
Motivation
----------
Sometimes, users want to be able to execute the entry actions of the
state machine when this one starts. This is the implementation of that
feature to avoid devs rewriting always the same workaround.

Modifications
-------------
New flag in StateMachineConfig to decide whether or not to execute the
entry actions of the state machine when it starts. StateMachine
constructor updated to check that flag and call the enter method when it
is true. Two unit tests to verify the default behavior is backward
compatible and the new behavior is working.
Version upgraded from 2.5.1-SNAPSHOT to 2.5.2-SNAPSHOT

Result
------
One can choose to execute entry actions of the initial state of the
state machine when this one starts.