### PR TITLE
Template for deploying snapshots from Travis

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Deploy a jar, source jar, and javadoc jar to Sonatype's snapshot repo.
+#
+# Adapted from https://coderwall.com/p/9b_lfq and
+# http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
+
+SLUG="oxo42/stateless4j"
+JDK="openjdk7"
+BRANCH="master"
+
+set -e
+
+if [ "$TRAVIS_REPO_SLUG" != "$SLUG" ]; then
+  echo "Skipping snapshot deployment: wrong repository. Expected '$SLUG' but was '$TRAVIS_REPO_SLUG'."
+elif [ "$TRAVIS_JDK_VERSION" != "$JDK" ]; then
+  echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$TRAVIS_JDK_VERSION'."
+elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "Skipping snapshot deployment: was pull request."
+elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
+  echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '$TRAVIS_BRANCH'."
+else
+  echo "Deploying snapshot..."
+  mvn clean source:jar javadoc:jar deploy --settings=".buildscript/settings.xml" -Dmaven.test.skip=true
+  echo "Snapshot deployed!"
+fi

--- a/.buildscript/settings.xml
+++ b/.buildscript/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+    <servers>
+        <server>
+            <id>sonatype-nexus-snapshots</id>
+            <username>${env.CI_DEPLOY_USERNAME}</username>
+            <password>${env.CI_DEPLOY_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,16 @@
 language: java
 jdk:
   - openjdk7
+
+after_success:
+  - .buildscript/deploy_snapshot.sh
+
+env:
+  global:
+  # TODO see http://docs.travis-ci.com/user/environment-variables/#Secure-Variables
+    - secure: "CI_DEPLOY_USERNAME=<your_username>"
+    - secure: "CI_DEPLOY_PASSWORD=<your_password>"
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ assertEquals(State.Ringing, phoneCall.getState());
 
 stateless4j is a port of [stateless](https://github.com/nblumhardt/stateless) for java
 
+Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].
+
 
 Features
 ========
@@ -92,3 +94,5 @@ source and destination states.
 License
 =======
 Apache 2.0 License
+
+[snap]: https://oss.sonatype.org/content/repositories/snapshots/


### PR DESCRIPTION
Adds the required template for deploying SNAPSHOTs to Sonatype from Travis whenever a build on the master branch completes successfully.

@oxo42 would need to modify `.travis.yml` to supply the correct Sonatype credentials