### PR TITLE
Issue-40 Remove debug logging when transitioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,6 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-jdk14</artifactId>
-          <version>1.7.7</version>
-        </dependency>
     </dependencies>
     <developers>
         <developer>

--- a/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
@@ -5,8 +5,6 @@ import com.github.oxo42.stateless4j.delegates.Action2;
 import com.github.oxo42.stateless4j.delegates.Func;
 import com.github.oxo42.stateless4j.transitions.Transition;
 import com.github.oxo42.stateless4j.triggers.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +20,6 @@ public class StateMachine<S, T> {
     protected final StateMachineConfig<S, T> config;
     protected final Func<S> stateAccessor;
     protected final Action1<S> stateMutator;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     protected Action2<S, T> unhandledTriggerAction = new Action2<S, T>() {
 
         public void doIt(S state, T trigger) {
@@ -185,7 +182,6 @@ public class StateMachine<S, T> {
     }
 
     protected void publicFire(T trigger, Object... args) {
-        logger.info("Firing " + trigger);
         TriggerWithParameters<S, T> configuration = config.getTriggerConfiguration(trigger);
         if (configuration != null) {
             configuration.validateParameters(args);


### PR DESCRIPTION
This change removes the slf4j dependency as the only logging was
the single line of debug.  This leaves the logging choice up to the
application using the library.
