### PR TITLE
Issue-40 Reduce logging from Info to Debug when transitioning

### DIFF
--- a/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
@@ -185,7 +185,7 @@ public class StateMachine<S, T> {
     }
 
     protected void publicFire(T trigger, Object... args) {
-        logger.info("Firing " + trigger);
+        logger.debug("Firing {}", trigger);
         TriggerWithParameters<S, T> configuration = config.getTriggerConfiguration(trigger);
         if (configuration != null) {
             configuration.validateParameters(args);


### PR DESCRIPTION
https://github.com/oxo42/stateless4j/pull/42 is the preferred solution since it makes stateless4j un-opinionated about logging and leaves it to the application.  This alternative logs the debug message at debug level.
