### PR TITLE
Don't depend on specific slf4j binding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
           <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-jdk14</artifactId>
+          <artifactId>slf4j-api</artifactId>
           <version>1.7.7</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
There is more than one slf4j output binding (simple (stderr), log4j12, jdk14, logback).
Authors who use stateless4j have to exclude this depedency manually if they don't want to load `slf4j-jdk14` binding (e.g. loading this binding may produce warning if `slf4j-simple` is also loaded).
The solution is to depend only on slf4j API and not on specific binding.
