### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/src/main/java/com/github/oxo42/stateless4j/StateConfiguration.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateConfiguration.java
@@ -13,6 +13,10 @@ public class StateConfiguration<S, T> {
             return true;
         }
     };
+    public static final String GUARD_IS_NULL = "guard is null";
+    public static final String ENTRY_ACTION_IS_NULL = "entryAction is null";
+    public static final String TRIGGER_IS_NULL = "trigger is null";
+    public static final String DESTINATION_STATE_SELECTOR_IS_NULL = "destinationStateSelector is null";
     private final StateRepresentation<S, T> representation;
     private final Func2<S, StateRepresentation<S, T>> lookup;
 
@@ -95,7 +99,7 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public StateConfiguration<S, T> ignoreIf(T trigger, FuncBoolean guard) {
-        assert guard != null : "guard is null";
+        assert guard != null : GUARD_IS_NULL;
         representation.addTriggerBehaviour(new IgnoredTriggerBehaviour<S, T>(trigger, guard));
         return this;
     }
@@ -107,7 +111,7 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public StateConfiguration<S, T> onEntry(final Action entryAction) {
-        assert entryAction != null : "entryAction is null";
+        assert entryAction != null : ENTRY_ACTION_IS_NULL;
         return onEntry(new Action1<Transition<S, T>>() {
             @Override
             public void doIt(Transition<S, T> t) {
@@ -123,7 +127,7 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public StateConfiguration<S, T> onEntry(final Action1<Transition<S, T>> entryAction) {
-        assert entryAction != null : "entryAction is null";
+        assert entryAction != null : ENTRY_ACTION_IS_NULL;
         representation.addEntryAction(new Action2<Transition<S, T>, Object[]>() {
             @Override
             public void doIt(Transition<S, T> arg1, Object[] arg2) {
@@ -141,7 +145,7 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public StateConfiguration<S, T> onEntryFrom(T trigger, final Action entryAction) {
-        assert entryAction != null : "entryAction is null";
+        assert entryAction != null : ENTRY_ACTION_IS_NULL;
         return onEntryFrom(trigger, new Action1<Transition<S, T>>() {
             @Override
             public void doIt(Transition<S, T> arg1) {
@@ -158,7 +162,7 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public StateConfiguration<S, T> onEntryFrom(T trigger, final Action1<Transition<S, T>> entryAction) {
-        assert entryAction != null : "entryAction is null";
+        assert entryAction != null : ENTRY_ACTION_IS_NULL;
         representation.addEntryAction(trigger, new Action2<Transition<S, T>, Object[]>() {
             @Override
             public void doIt(Transition<S, T> arg1, Object[] arg2) {
@@ -178,7 +182,7 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public <TArg0> StateConfiguration<S, T> onEntryFrom(TriggerWithParameters1<TArg0, S, T> trigger, final Action1<TArg0> entryAction, final Class<TArg0> classe0) {
-        assert entryAction != null : "entryAction is null";
+        assert entryAction != null : ENTRY_ACTION_IS_NULL;
         return onEntryFrom(trigger, new Action2<TArg0, Transition<S, T>>() {
             @Override
             public void doIt(TArg0 arg1, Transition<S, T> arg2) {
@@ -197,8 +201,8 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public <TArg0> StateConfiguration<S, T> onEntryFrom(TriggerWithParameters1<TArg0, S, T> trigger, final Action2<TArg0, Transition<S, T>> entryAction, final Class<TArg0> classe0) {
-        assert trigger != null : "trigger is null";
-        assert entryAction != null : "entryAction is null";
+        assert trigger != null : TRIGGER_IS_NULL;
+        assert entryAction != null : ENTRY_ACTION_IS_NULL;
         representation.addEntryAction(trigger.getTrigger(), new Action2<Transition<S, T>, Object[]>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -221,7 +225,7 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public <TArg0, TArg1> StateConfiguration<S, T> onEntryFrom(TriggerWithParameters2<TArg0, TArg1, S, T> trigger, final Action2<TArg0, TArg1> entryAction, final Class<TArg0> classe0, final Class<TArg1> classe1) {
-        assert entryAction != null : "entryAction is null";
+        assert entryAction != null : ENTRY_ACTION_IS_NULL;
         return onEntryFrom(trigger, new Action3<TArg0, TArg1, Transition<S, T>>() {
             @Override
             public void doIt(TArg0 a0, TArg1 a1, Transition<S, T> t) {
@@ -242,8 +246,8 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public <TArg0, TArg1> StateConfiguration<S, T> onEntryFrom(TriggerWithParameters2<TArg0, TArg1, S, T> trigger, final Action3<TArg0, TArg1, Transition<S, T>> entryAction, final Class<TArg0> classe0, final Class<TArg1> classe1) {
-        assert trigger != null : "trigger is null";
-        assert entryAction != null : "entryAction is null";
+        assert trigger != null : TRIGGER_IS_NULL;
+        assert entryAction != null : ENTRY_ACTION_IS_NULL;
         representation.addEntryAction(trigger.getTrigger(), new Action2<Transition<S, T>, Object[]>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -270,7 +274,7 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public <TArg0, TArg1, TArg2> StateConfiguration<S, T> onEntryFrom(TriggerWithParameters3<TArg0, TArg1, TArg2, S, T> trigger, final Action3<TArg0, TArg1, TArg2> entryAction, final Class<TArg0> classe0, final Class<TArg1> classe1, final Class<TArg2> classe2) {
-        assert entryAction != null : "entryAction is null";
+        assert entryAction != null : ENTRY_ACTION_IS_NULL;
         return onEntryFrom(trigger, new Action4<TArg0, TArg1, TArg2, Transition<S, T>>() {
             @Override
             public void doIt(TArg0 a0, TArg1 a1, TArg2 a2, Transition<S, T> t) {
@@ -293,8 +297,8 @@ public class StateConfiguration<S, T> {
      * @return The receiver
      */
     public <TArg0, TArg1, TArg2> StateConfiguration<S, T> onEntryFrom(TriggerWithParameters3<TArg0, TArg1, TArg2, S, T> trigger, final Action4<TArg0, TArg1, TArg2, Transition<S, T>> entryAction, final Class<TArg0> classe0, final Class<TArg1> classe1, final Class<TArg2> classe2) {
-        assert trigger != null : "trigger is null";
-        assert entryAction != null : "entryAction is null";
+        assert trigger != null : TRIGGER_IS_NULL;
+        assert entryAction != null : ENTRY_ACTION_IS_NULL;
         representation.addEntryAction(trigger.getTrigger(), new Action2<Transition<S, T>, Object[]>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -421,7 +425,7 @@ public class StateConfiguration<S, T> {
      * @return The reciever
      */
     public StateConfiguration<S, T> permitDynamicIf(T trigger, final Func<S> destinationStateSelector, FuncBoolean guard) {
-        assert destinationStateSelector != null : "destinationStateSelector is null";
+        assert destinationStateSelector != null : DESTINATION_STATE_SELECTOR_IS_NULL;
         return publicPermitDynamicIf(trigger, new Func2<Object[], S>() {
             @Override
             public S call(Object[] arg0) {
@@ -441,8 +445,8 @@ public class StateConfiguration<S, T> {
      * @return The reciever
      */
     public <TArg0> StateConfiguration<S, T> permitDynamicIf(TriggerWithParameters1<TArg0, S, T> trigger, final Func2<TArg0, S> destinationStateSelector, FuncBoolean guard) {
-        assert trigger != null : "trigger is null";
-        assert destinationStateSelector != null : "destinationStateSelector is null";
+        assert trigger != null : TRIGGER_IS_NULL;
+        assert destinationStateSelector != null : DESTINATION_STATE_SELECTOR_IS_NULL;
         return publicPermitDynamicIf(
                 trigger.getTrigger(), new Func2<Object[], S>() {
                     @SuppressWarnings("unchecked")
@@ -468,8 +472,8 @@ public class StateConfiguration<S, T> {
      * @return The reciever
      */
     public <TArg0, TArg1> StateConfiguration<S, T> permitDynamicIf(TriggerWithParameters2<TArg0, TArg1, S, T> trigger, final Func3<TArg0, TArg1, S> destinationStateSelector, FuncBoolean guard) {
-        assert trigger != null : "trigger is null";
-        assert destinationStateSelector != null : "destinationStateSelector is null";
+        assert trigger != null : TRIGGER_IS_NULL;
+        assert destinationStateSelector != null : DESTINATION_STATE_SELECTOR_IS_NULL;
         return publicPermitDynamicIf(
                 trigger.getTrigger(), new Func2<Object[], S>() {
                     @SuppressWarnings("unchecked")
@@ -499,8 +503,8 @@ public class StateConfiguration<S, T> {
      */
     public <TArg0, TArg1, TArg2> StateConfiguration<S, T> permitDynamicIf(TriggerWithParameters3<TArg0, TArg1, TArg2, S, T> trigger,
             final Func4<TArg0, TArg1, TArg2, S> destinationStateSelector, FuncBoolean guard) {
-        assert trigger != null : "trigger is null";
-        assert destinationStateSelector != null : "destinationStateSelector is null";
+        assert trigger != null : TRIGGER_IS_NULL;
+        assert destinationStateSelector != null : DESTINATION_STATE_SELECTOR_IS_NULL;
         return publicPermitDynamicIf(
                 trigger.getTrigger(), new Func2<Object[], S>() {
                     @SuppressWarnings("unchecked")
@@ -528,7 +532,7 @@ public class StateConfiguration<S, T> {
     }
 
     StateConfiguration<S, T> publicPermitIf(T trigger, S destinationState, FuncBoolean guard) {
-        assert guard != null : "guard is null";
+        assert guard != null : GUARD_IS_NULL;
         representation.addTriggerBehaviour(new TransitioningTriggerBehaviour<>(trigger, destinationState, guard));
         return this;
     }
@@ -538,8 +542,8 @@ public class StateConfiguration<S, T> {
     }
 
     StateConfiguration<S, T> publicPermitDynamicIf(T trigger, Func2<Object[], S> destinationStateSelector, FuncBoolean guard) {
-        assert destinationStateSelector != null : "destinationStateSelector is null";
-        assert guard != null : "guard is null";
+        assert destinationStateSelector != null : DESTINATION_STATE_SELECTOR_IS_NULL;
+        assert guard != null : GUARD_IS_NULL;
         representation.addTriggerBehaviour(new DynamicTriggerBehaviour<>(trigger, destinationStateSelector, guard));
         return this;
     }

--- a/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
@@ -19,6 +19,7 @@ import java.util.List;
  */
 public class StateMachine<S, T> {
 
+    public static final String TRIGGER_IS_NULL = "trigger is null";
     protected final StateMachineConfig<S, T> config;
     protected final Func<S> stateAccessor;
     protected final Action1<S> stateMutator;
@@ -144,7 +145,7 @@ public class StateMachine<S, T> {
      * @param <TArg0> Type of the first trigger argument
      */
     public <TArg0> void fire(TriggerWithParameters1<TArg0, S, T> trigger, TArg0 arg0) {
-        assert trigger != null : "trigger is null";
+        assert trigger != null : TRIGGER_IS_NULL;
         publicFire(trigger.getTrigger(), arg0);
     }
 
@@ -161,7 +162,7 @@ public class StateMachine<S, T> {
      * @param <TArg1> Type of the second trigger argument
      */
     public <TArg0, TArg1> void fire(TriggerWithParameters2<TArg0, TArg1, S, T> trigger, TArg0 arg0, TArg1 arg1) {
-        assert trigger != null : "trigger is null";
+        assert trigger != null : TRIGGER_IS_NULL;
         publicFire(trigger.getTrigger(), arg0, arg1);
     }
 
@@ -180,7 +181,7 @@ public class StateMachine<S, T> {
      * @param <TArg2> Type of the third trigger argument
      */
     public <TArg0, TArg1, TArg2> void fire(TriggerWithParameters3<TArg0, TArg1, TArg2, S, T> trigger, TArg0 arg0, TArg1 arg1, TArg2 arg2) {
-        assert trigger != null : "trigger is null";
+        assert trigger != null : TRIGGER_IS_NULL;
         publicFire(trigger.getTrigger(), arg0, arg1, arg2);
     }
 

--- a/src/main/java/com/github/oxo42/stateless4j/StateRepresentation.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateRepresentation.java
@@ -13,6 +13,8 @@ import java.util.Set;
 
 public class StateRepresentation<S, T> {
 
+    public static final String ACTION_IS_NULL = "action is null";
+    public static final String TRANSITION_IS_NULL = "transition is null";
     private final S state;
 
     private final Map<T, List<TriggerBehaviour<S, T>>> triggerBehaviours = new HashMap<>();
@@ -62,7 +64,7 @@ public class StateRepresentation<S, T> {
     }
 
     public void addEntryAction(final T trigger, final Action2<Transition<S, T>, Object[]> action) {
-        assert action != null : "action is null";
+        assert action != null : ACTION_IS_NULL;
 
         entryActions.add(new Action2<Transition<S, T>, Object[]>() {
             @Override
@@ -76,22 +78,22 @@ public class StateRepresentation<S, T> {
     }
 
     public void addEntryAction(Action2<Transition<S, T>, Object[]> action) {
-        assert action != null : "action is null";
+        assert action != null : ACTION_IS_NULL;
         entryActions.add(action);
     }
 
     public void insertEntryAction(Action2<Transition<S, T>, Object[]> action) {
-        assert action != null : "action is null";
+        assert action != null : ACTION_IS_NULL;
         entryActions.add(0, action);
     }
 
     public void addExitAction(Action1<Transition<S, T>> action) {
-        assert action != null : "action is null";
+        assert action != null : ACTION_IS_NULL;
         exitActions.add(action);
     }
 
     public void enter(Transition<S, T> transition, Object... entryArgs) {
-        assert transition != null : "transition is null";
+        assert transition != null : TRANSITION_IS_NULL;
 
         if (transition.isReentry()) {
             executeEntryActions(transition, entryArgs);
@@ -105,7 +107,7 @@ public class StateRepresentation<S, T> {
     }
 
     public void exit(Transition<S, T> transition) {
-        assert transition != null : "transition is null";
+        assert transition != null : TRANSITION_IS_NULL;
 
         if (transition.isReentry()) {
             executeExitActions(transition);
@@ -118,7 +120,7 @@ public class StateRepresentation<S, T> {
     }
 
     void executeEntryActions(Transition<S, T> transition, Object[] entryArgs) {
-        assert transition != null : "transition is null";
+        assert transition != null : TRANSITION_IS_NULL;
         assert entryArgs != null : "entryArgs is null";
         for (Action2<Transition<S, T>, Object[]> action : entryActions) {
             action.doIt(transition, entryArgs);
@@ -126,7 +128,7 @@ public class StateRepresentation<S, T> {
     }
 
     void executeExitActions(Transition<S, T> transition) {
-        assert transition != null : "transition is null";
+        assert transition != null : TRANSITION_IS_NULL;
         for (Action1<Transition<S, T>> action : exitActions) {
             action.doIt(transition);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava
