### PR TITLE
Issue-15: Support action on transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Most standard state machine constructs are supported:
 * Hierarchical states
 * Entry/exit events for states
 * Guard clauses to support conditional transitions
+* User-defined actions can be executed when transitioning
 * Introspection
 
 
@@ -88,6 +89,23 @@ methods being called repeatedly because the `OnHold` state is a substate of the 
 
 Entry/Exit event handlers can be supplied with a parameter of type `Transition` that describes the trigger,
 source and destination states.
+
+Action on transition
+===================
+It is possible to execute a user-defined action when doing a transition.
+For a 'normal' or 're-entrant' transition this action will be called
+without any parameters. For 'dynamic' transitions (those who compute the
+target state based on trigger-given parameters) the parameters of the
+trigger will be given to the action.
+
+This action is only executed if the transition is actually taken; so if
+the transition is guarded and the guard forbids a transition, then the
+action is not executed.
+
+If the transition is taken, the action will be executed between the
+`onExit` handler of the current state and the `onEntry` handler of the
+target state (which might be the same state in case of a re-entrant
+transition.
 
 License
 =======

--- a/examples/PhoneCallJava7.java
+++ b/examples/PhoneCallJava7.java
@@ -23,6 +23,12 @@ public class PhoneCallJava7 {
                 stopCallTimer();
             }
         };
+        Action reportLeftMessage = new Action() {
+            @Override
+            public void doIt() {
+                System.out.println("Received 'LeftMessage' in 'Connected'");
+            }
+        };
 
         StateMachineConfig<State, Trigger> phoneCallConfig = new StateMachineConfig<>();
 
@@ -36,7 +42,7 @@ public class PhoneCallJava7 {
         phoneCallConfig.configure(State.Connected)
                 .onEntry(callStartTimer)
                 .onExit(callStopTimer)
-                .permit(Trigger.LeftMessage, State.OffHook)
+                .permit(Trigger.LeftMessage, State.OffHook, reportLeftMessage)
                 .permit(Trigger.HungUp, State.OffHook)
                 .permit(Trigger.PlacedOnHold, State.OnHold);
 

--- a/src/main/java/com/github/oxo42/stateless4j/StateConfiguration.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateConfiguration.java
@@ -108,6 +108,24 @@ public class StateConfiguration<S, T> {
      * <p>
      * Applies to the current state only. Will not re-execute superstate actions, or  cause actions to execute
      * transitioning between super- and sub-states
+     * <p>
+     * Additionally a given action is performed when transitioning. This action will be called after
+     * the onExit action and before the onEntry action (of the re-entered state).
+     *
+     * @param trigger The accepted trigger
+     * @param action  The action to be performed "during" transition
+     * @return The reciever
+     */
+    public StateConfiguration<S, T> permitReentry(T trigger, Action action) {
+        return publicPermit(trigger, representation.getUnderlyingState(), action);
+    }
+
+    /**
+     * Accept the specified trigger, execute exit actions and re-execute entry actions. Reentry behaves as though the
+     * configured state transitions to an identical sibling state
+     * <p>
+     * Applies to the current state only. Will not re-execute superstate actions, or  cause actions to execute
+     * transitioning between super- and sub-states
      *
      * @param trigger The accepted trigger
      * @param guard   Function that must return true in order for the trigger to be accepted
@@ -115,6 +133,24 @@ public class StateConfiguration<S, T> {
      */
     public StateConfiguration<S, T> permitReentryIf(T trigger, FuncBoolean guard) {
         return publicPermitIf(trigger, representation.getUnderlyingState(), guard);
+    }
+
+    /**
+     * Accept the specified trigger, execute exit actions and re-execute entry actions. Reentry behaves as though the
+     * configured state transitions to an identical sibling state
+     * <p>
+     * Applies to the current state only. Will not re-execute superstate actions, or  cause actions to execute
+     * transitioning between super- and sub-states
+     * <p>
+     * Additionally a given action is performed when transitioning. This action will be called after
+     * the onExit action and before the onEntry action (of the re-entered state).
+     *
+     * @param trigger The accepted trigger
+     * @param guard   Function that must return true in order for the trigger to be accepted
+     * @return The reciever
+     */
+    public StateConfiguration<S, T> permitReentryIf(T trigger, FuncBoolean guard, Action action) {
+        return publicPermitIf(trigger, representation.getUnderlyingState(), guard, action);
     }
 
     /**

--- a/src/main/java/com/github/oxo42/stateless4j/StateConfiguration.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateConfiguration.java
@@ -18,6 +18,11 @@ public class StateConfiguration<S, T> {
         public void doIt() {
         }
     };
+    private static final Action1<Object[]> NO_ACTION_N = new Action1<Object[]>() {
+    	@Override
+    	public void doIt(Object[] args) {
+    	}
+    };
     private final StateRepresentation<S, T> representation;
     private final Func2<S, StateRepresentation<S, T>> lookup;
 
@@ -172,7 +177,7 @@ public class StateConfiguration<S, T> {
      */
     public StateConfiguration<S, T> ignoreIf(T trigger, FuncBoolean guard) {
         assert guard != null : "guard is null";
-        representation.addTriggerBehaviour(new IgnoredTriggerBehaviour<S, T>(trigger, guard, NO_ACTION));
+        representation.addTriggerBehaviour(new IgnoredTriggerBehaviour<S, T>(trigger, guard));
         return this;
     }
 
@@ -446,6 +451,22 @@ public class StateConfiguration<S, T> {
     /**
      * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
      * function
+     * <p>
+     * Additionally a given action is performed when transitioning. This action will be called after
+     * the onExit action and before the onEntry action (of the re-entered state).
+     *
+     * @param trigger                  The accepted trigger
+     * @param destinationStateSelector Function to calculate the state that the trigger will cause a transition to
+     * @param action                   The action to be performed "during" transition
+     * @return The receiver
+     */
+    public StateConfiguration<S, T> permitDynamic(T trigger, final Func<S> destinationStateSelector, Action action) {
+        return permitDynamicIf(trigger, destinationStateSelector, NO_GUARD, action);
+    }
+
+    /**
+     * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
+     * function
      *
      * @param trigger                  The accepted trigger
      * @param destinationStateSelector Function to calculate the state that the trigger will cause a transition to
@@ -456,6 +477,25 @@ public class StateConfiguration<S, T> {
         return permitDynamicIf(trigger, destinationStateSelector, NO_GUARD);
     }
 
+    /**
+     * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
+     * function
+     * <p>
+     * Additionally a given action is performed when transitioning. This action will be called after
+     * the onExit action and before the onEntry action (of the re-entered state). The parameter of the
+     * trigger will be given to this action.
+     *
+     * @param trigger                  The accepted trigger
+     * @param destinationStateSelector Function to calculate the state that the trigger will cause a transition to
+     * @param action                   The action to be performed "during" transition
+     * @param <TArg0>                  Type of the first trigger argument
+     * @return The receiver
+     */
+    public <TArg0> StateConfiguration<S, T> permitDynamic(TriggerWithParameters1<TArg0, S, T> trigger,
+    		Func2<TArg0, S> destinationStateSelector, Action1<TArg0> action) {
+        return permitDynamicIf(trigger, destinationStateSelector, NO_GUARD, action);
+    }
+    
     /**
      * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
      * function
@@ -470,6 +510,28 @@ public class StateConfiguration<S, T> {
             TriggerWithParameters2<TArg0, TArg1, S, T> trigger,
             Func3<TArg0, TArg1, S> destinationStateSelector) {
         return permitDynamicIf(trigger, destinationStateSelector, NO_GUARD);
+    }
+
+    
+    /**
+     * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
+     * function
+     * <p>
+     * Additionally a given action is performed when transitioning. This action will be called after
+     * the onExit action and before the onEntry action (of the re-entered state). The parameters of the
+     * trigger will be given to this action.
+     *
+     * @param trigger                  The accepted trigger
+     * @param destinationStateSelector Function to calculate the state that the trigger will cause a transition to
+     * @param action                   The action to be performed "during" transition
+     * @param <TArg0>                  Type of the first trigger argument
+     * @param <TArg1>                  Type of the second trigger argument
+     * @return The receiver
+     */
+    public <TArg0, TArg1> StateConfiguration<S, T> permitDynamic(
+            TriggerWithParameters2<TArg0, TArg1, S, T> trigger,
+            Func3<TArg0, TArg1, S> destinationStateSelector, Action2<TArg0, TArg1> action) {
+        return permitDynamicIf(trigger, destinationStateSelector, NO_GUARD, action);
     }
 
     /**
@@ -487,6 +549,29 @@ public class StateConfiguration<S, T> {
         return permitDynamicIf(trigger, destinationStateSelector, NO_GUARD);
     }
 
+
+    /**
+     * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
+     * function
+     * <p>
+     * Additionally a given action is performed when transitioning. This action will be called after
+     * the onExit action and before the onEntry action (of the re-entered state). The parameters of the
+     * trigger will be given to this action.
+     *
+     * @param trigger                  The accepted trigger
+     * @param destinationStateSelector Function to calculate the state that the trigger will cause a transition to
+     * @param action                   The action to be performed "during" transition
+     * @param <TArg0>                  Type of the first trigger argument
+     * @param <TArg1>                  Type of the second trigger argument
+     * @param <TArg2>                  Type of the third trigger argument
+     * @return The receiver
+     */
+    public <TArg0, TArg1, TArg2> StateConfiguration<S, T> permitDynamic(TriggerWithParameters3<TArg0, TArg1, TArg2, S, T> trigger,
+    		final Func4<TArg0, TArg1, TArg2, S> destinationStateSelector,
+    		final Action3<TArg0, TArg1, TArg2> action) {
+        return permitDynamicIf(trigger, destinationStateSelector, NO_GUARD, action);
+    }
+    
     /**
      * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
      * function
@@ -503,7 +588,37 @@ public class StateConfiguration<S, T> {
             public S call(Object[] arg0) {
                 return destinationStateSelector.call();
             }
-        }, guard);
+        }, guard, NO_ACTION_N);
+    }
+
+    /**
+     * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
+     * function
+     * <p>
+     * Additionally a given action is performed when transitioning. This action will be called after
+     * the onExit action of the current state and before the onEntry action of the destination state.
+     *
+     * @param trigger                  The accepted trigger
+     * @param destinationStateSelector Function to calculate the state that the trigger will cause a transition to
+     * @param guard                    Function that must return true in order for the  trigger to be accepted
+     * @param action                   The action to be performed "during" transition
+     * @return The receiver
+     */
+    public StateConfiguration<S, T> permitDynamicIf(T trigger, final Func<S> destinationStateSelector, FuncBoolean guard,
+    		final Action action) {
+        assert destinationStateSelector != null : "destinationStateSelector is null";
+        return publicPermitDynamicIf(trigger, new Func2<Object[], S>() {
+            @Override
+            public S call(Object[] arg0) {
+                return destinationStateSelector.call();
+            }
+        }, guard, new Action1<Object[]>() {
+            @SuppressWarnings("unchecked")
+        	@Override
+        	public void doIt(Object[] args) {
+        		action.doIt();
+        	}
+        });
     }
 
     /**
@@ -528,7 +643,45 @@ public class StateConfiguration<S, T> {
 
                     }
                 },
-                guard
+                guard, NO_ACTION_N
+        );
+    }
+
+    /**
+     * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
+     * function
+     * <p>
+     * Additionally a given action is performed when transitioning. This action will be called after
+     * the onExit action of the current state and before the onEntry action of the destination state.
+     * The parameter of the trigger will be given to this action.
+     *
+     * @param trigger                  The accepted trigger
+     * @param destinationStateSelector Function to calculate the state that the trigger will cause a transition to
+     * @param guard                    Function that must return true in order for the  trigger to be accepted
+     * @param action                   The action to be performed "during" transition
+     * @param <TArg0>                  Type of the first trigger argument
+     * @return The receiver
+     */
+    public <TArg0> StateConfiguration<S, T> permitDynamicIf(TriggerWithParameters1<TArg0, S, T> trigger,final Func2<TArg0, S> destinationStateSelector, FuncBoolean guard,
+    		final Action1<TArg0> action) {
+        assert trigger != null : "trigger is null";
+        assert destinationStateSelector != null : "destinationStateSelector is null";
+        return publicPermitDynamicIf(
+                trigger.getTrigger(), new Func2<Object[], S>() {
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    public S call(Object[] args) {
+                        return destinationStateSelector.call((TArg0) args[0]);
+
+                    }
+                },
+                guard, new Action1<Object[]>() {
+                    @SuppressWarnings("unchecked")
+                	@Override
+                	public void doIt(Object[] args) {
+                		action.doIt((TArg0) args[0]);
+                	}
+                }
         );
     }
 
@@ -557,7 +710,50 @@ public class StateConfiguration<S, T> {
                                 (TArg1) args[1]);
                     }
                 },
-                guard
+                guard, NO_ACTION_N
+        );
+    }
+
+    /**
+     * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
+     * function
+     * <p>
+     * Additionally a given action is performed when transitioning. This action will be called after
+     * the onExit action of the current state and before the onEntry action of the destination state.
+     * The parameters of the trigger will be given to this action.
+     *
+     * @param trigger                  The accepted trigger
+     * @param destinationStateSelector Function to calculate the state that the trigger will cause a transition to
+     * @param guard                    Function that must return true in order for the  trigger to be accepted
+     * @param action                   The action to be performed "during" transition
+     * @param <TArg0>                  Type of the first trigger argument
+     * @param <TArg1>                  Type of the second trigger argument
+     * @return The receiver
+     */
+    public <TArg0, TArg1> StateConfiguration<S, T> permitDynamicIf(TriggerWithParameters2<TArg0, TArg1, S, T> trigger, final Func3<TArg0, TArg1, S> destinationStateSelector, FuncBoolean guard,
+    		final Action2<TArg0, TArg1> action) {
+        assert trigger != null : "trigger is null";
+        assert destinationStateSelector != null : "destinationStateSelector is null";
+        return publicPermitDynamicIf(
+                trigger.getTrigger(), new Func2<Object[], S>() {
+                    @SuppressWarnings("unchecked")
+
+                    @Override
+                    public S call(Object[] args) {
+                        return destinationStateSelector.call(
+                                (TArg0) args[0],
+                                (TArg1) args[1]);
+                    }
+                },
+                guard, new Action1<Object[]>() {
+                    @SuppressWarnings("unchecked")
+                	@Override
+                	public void doIt(Object[] args) {
+                		action.doIt(
+                				(TArg0) args[0],
+                				(TArg1) args[1]);
+                	}
+                }
         );
     }
 
@@ -589,7 +785,53 @@ public class StateConfiguration<S, T> {
                                 (TArg2) args[2]
                         );
                     }
-                }, guard
+                }, guard, NO_ACTION_N
+            );
+    }
+
+    /**
+     * Accept the specified trigger and transition to the destination state, calculated dynamically by the supplied
+     * function.
+     * <p>
+     * Additionally a given action is performed when transitioning. This action will be called after
+     * the onExit action of the current state and before the onEntry action of the destination state.
+     * The parameters of the trigger will be given to this action.
+     *
+     * @param trigger                  The accepted trigger
+     * @param destinationStateSelector Function to calculate the state that the trigger will cause a transition to
+     * @param guard                    Function that must return true in order for the  trigger to be accepted
+     * @param action                   The action to be performed "during" transition
+     * @param <TArg0>                  Type of the first trigger argument
+     * @param <TArg1>                  Type of the second trigger argument
+     * @param <TArg2>                  Type of the third trigger argument
+     * @return The reciever
+     */
+    public <TArg0, TArg1, TArg2> StateConfiguration<S, T> permitDynamicIf(TriggerWithParameters3<TArg0, TArg1, TArg2, S, T> trigger,
+            final Func4<TArg0, TArg1, TArg2, S> destinationStateSelector, FuncBoolean guard, final Action3<TArg0, TArg1, TArg2> action) {
+        assert trigger != null : "trigger is null";
+        assert destinationStateSelector != null : "destinationStateSelector is null";
+        return publicPermitDynamicIf(
+                trigger.getTrigger(), new Func2<Object[], S>() {
+                    @SuppressWarnings("unchecked")
+
+                    @Override
+                    public S call(Object[] args) {
+                        return destinationStateSelector.call(
+                                (TArg0) args[0],
+                                (TArg1) args[1],
+                                (TArg2) args[2]
+                        );
+                    }
+                }, guard, new Action1<Object[]>() {
+                    @SuppressWarnings("unchecked")
+                	@Override
+                	public void doIt(Object[] args) {
+                		action.doIt(
+                				(TArg0) args[0],
+                				(TArg1) args[1],
+                				(TArg2) args[2]);
+                	}
+                }
         );
     }
 
@@ -619,13 +861,13 @@ public class StateConfiguration<S, T> {
     }
 
     StateConfiguration<S, T> publicPermitDynamic(T trigger, Func2<Object[], S> destinationStateSelector) {
-        return publicPermitDynamicIf(trigger, destinationStateSelector, NO_GUARD);
+        return publicPermitDynamicIf(trigger, destinationStateSelector, NO_GUARD, NO_ACTION_N);
     }
 
-    StateConfiguration<S, T> publicPermitDynamicIf(T trigger, Func2<Object[], S> destinationStateSelector, FuncBoolean guard) {
+    StateConfiguration<S, T> publicPermitDynamicIf(T trigger, Func2<Object[], S> destinationStateSelector, FuncBoolean guard, Action1<Object[]> action) {
         assert destinationStateSelector != null : "destinationStateSelector is null";
         assert guard != null : "guard is null";
-        representation.addTriggerBehaviour(new DynamicTriggerBehaviour<>(trigger, destinationStateSelector, guard));
+        representation.addTriggerBehaviour(new DynamicTriggerBehaviour<>(trigger, destinationStateSelector, guard, action));
         return this;
     }
 }

--- a/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
@@ -203,7 +203,7 @@ public class StateMachine<S, T> {
             Transition<S, T> transition = new Transition<>(source, destination.get(), trigger);
 
             getCurrentRepresentation().exit(transition);
-            triggerBehaviour.performAction();
+            triggerBehaviour.performAction(args);
             setState(destination.get());
             getCurrentRepresentation().enter(transition, args);
         }

--- a/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
+++ b/src/main/java/com/github/oxo42/stateless4j/StateMachine.java
@@ -89,7 +89,7 @@ public class StateMachine<S, T> {
     public StateConfiguration<S, T> configure(S state) {
         return config.configure(state);
     }
-    
+
     public StateMachineConfig<S, T> configuration() {
         return config;
     }
@@ -203,6 +203,7 @@ public class StateMachine<S, T> {
             Transition<S, T> transition = new Transition<>(source, destination.get(), trigger);
 
             getCurrentRepresentation().exit(transition);
+            triggerBehaviour.performAction();
             setState(destination.get());
             getCurrentRepresentation().enter(transition, args);
         }

--- a/src/main/java/com/github/oxo42/stateless4j/transitions/TransitioningTriggerBehaviour.java
+++ b/src/main/java/com/github/oxo42/stateless4j/transitions/TransitioningTriggerBehaviour.java
@@ -1,6 +1,7 @@
 package com.github.oxo42.stateless4j.transitions;
 
 import com.github.oxo42.stateless4j.OutVar;
+import com.github.oxo42.stateless4j.delegates.Action;
 import com.github.oxo42.stateless4j.delegates.FuncBoolean;
 import com.github.oxo42.stateless4j.triggers.TriggerBehaviour;
 
@@ -8,8 +9,8 @@ public class TransitioningTriggerBehaviour<S, T> extends TriggerBehaviour<S, T> 
 
     private final S destination;
 
-    public TransitioningTriggerBehaviour(T trigger, S destination, FuncBoolean guard) {
-        super(trigger, guard);
+    public TransitioningTriggerBehaviour(T trigger, S destination, FuncBoolean guard, Action action) {
+        super(trigger, guard, action);
         this.destination = destination;
     }
 

--- a/src/main/java/com/github/oxo42/stateless4j/transitions/TransitioningTriggerBehaviour.java
+++ b/src/main/java/com/github/oxo42/stateless4j/transitions/TransitioningTriggerBehaviour.java
@@ -8,10 +8,17 @@ import com.github.oxo42.stateless4j.triggers.TriggerBehaviour;
 public class TransitioningTriggerBehaviour<S, T> extends TriggerBehaviour<S, T> {
 
     private final S destination;
+    private final Action action;
 
     public TransitioningTriggerBehaviour(T trigger, S destination, FuncBoolean guard, Action action) {
-        super(trigger, guard, action);
+        super(trigger, guard);
         this.destination = destination;
+        this.action = action;
+    }
+    
+    @Override
+    public void performAction(Object[] args) {
+        action.doIt();
     }
 
     @Override

--- a/src/main/java/com/github/oxo42/stateless4j/triggers/DynamicTriggerBehaviour.java
+++ b/src/main/java/com/github/oxo42/stateless4j/triggers/DynamicTriggerBehaviour.java
@@ -1,24 +1,25 @@
 package com.github.oxo42.stateless4j.triggers;
 
 import com.github.oxo42.stateless4j.OutVar;
-import com.github.oxo42.stateless4j.delegates.Action;
+import com.github.oxo42.stateless4j.delegates.Action1;
 import com.github.oxo42.stateless4j.delegates.Func2;
 import com.github.oxo42.stateless4j.delegates.FuncBoolean;
 
 public class DynamicTriggerBehaviour<S, T> extends TriggerBehaviour<S, T> {
 
     private final Func2<Object[], S> destination;
+    private final Action1<Object[]> action;
 
-    private static final Action NO_ACTION = new Action() {
-        @Override
-        public void doIt() {
-        }
-    };
-
-    public DynamicTriggerBehaviour(T trigger, Func2<Object[], S> destination, FuncBoolean guard) {
-        super(trigger, guard, NO_ACTION);
+    public DynamicTriggerBehaviour(T trigger, Func2<Object[], S> destination, FuncBoolean guard, Action1<Object[]> action) {
+        super(trigger, guard);
         assert destination != null : "destination is null";
         this.destination = destination;
+        this.action = action;
+    }
+    
+    @Override
+    public void performAction(Object[] args) {
+    	action.doIt(args);
     }
 
     @Override

--- a/src/main/java/com/github/oxo42/stateless4j/triggers/DynamicTriggerBehaviour.java
+++ b/src/main/java/com/github/oxo42/stateless4j/triggers/DynamicTriggerBehaviour.java
@@ -1,6 +1,7 @@
 package com.github.oxo42.stateless4j.triggers;
 
 import com.github.oxo42.stateless4j.OutVar;
+import com.github.oxo42.stateless4j.delegates.Action;
 import com.github.oxo42.stateless4j.delegates.Func2;
 import com.github.oxo42.stateless4j.delegates.FuncBoolean;
 
@@ -8,8 +9,14 @@ public class DynamicTriggerBehaviour<S, T> extends TriggerBehaviour<S, T> {
 
     private final Func2<Object[], S> destination;
 
+    private static final Action NO_ACTION = new Action() {
+        @Override
+        public void doIt() {
+        }
+    };
+
     public DynamicTriggerBehaviour(T trigger, Func2<Object[], S> destination, FuncBoolean guard) {
-        super(trigger, guard);
+        super(trigger, guard, NO_ACTION);
         assert destination != null : "destination is null";
         this.destination = destination;
     }

--- a/src/main/java/com/github/oxo42/stateless4j/triggers/IgnoredTriggerBehaviour.java
+++ b/src/main/java/com/github/oxo42/stateless4j/triggers/IgnoredTriggerBehaviour.java
@@ -1,12 +1,13 @@
 package com.github.oxo42.stateless4j.triggers;
 
 import com.github.oxo42.stateless4j.OutVar;
+import com.github.oxo42.stateless4j.delegates.Action;
 import com.github.oxo42.stateless4j.delegates.FuncBoolean;
 
 public class IgnoredTriggerBehaviour<TState, TTrigger> extends TriggerBehaviour<TState, TTrigger> {
 
-    public IgnoredTriggerBehaviour(TTrigger trigger, FuncBoolean guard) {
-        super(trigger, guard);
+    public IgnoredTriggerBehaviour(TTrigger trigger, FuncBoolean guard, Action action) {
+        super(trigger, guard, action);
     }
 
     @Override

--- a/src/main/java/com/github/oxo42/stateless4j/triggers/IgnoredTriggerBehaviour.java
+++ b/src/main/java/com/github/oxo42/stateless4j/triggers/IgnoredTriggerBehaviour.java
@@ -1,13 +1,17 @@
 package com.github.oxo42.stateless4j.triggers;
 
 import com.github.oxo42.stateless4j.OutVar;
-import com.github.oxo42.stateless4j.delegates.Action;
 import com.github.oxo42.stateless4j.delegates.FuncBoolean;
 
 public class IgnoredTriggerBehaviour<TState, TTrigger> extends TriggerBehaviour<TState, TTrigger> {
 
-    public IgnoredTriggerBehaviour(TTrigger trigger, FuncBoolean guard, Action action) {
-        super(trigger, guard, action);
+    public IgnoredTriggerBehaviour(TTrigger trigger, FuncBoolean guard) {
+        super(trigger, guard);
+    }
+    
+    @Override
+    public void performAction(Object[] args) {
+        // no need to do anything. This is never called (no transition => no action)
     }
 
     @Override

--- a/src/main/java/com/github/oxo42/stateless4j/triggers/TriggerBehaviour.java
+++ b/src/main/java/com/github/oxo42/stateless4j/triggers/TriggerBehaviour.java
@@ -1,5 +1,6 @@
 package com.github.oxo42.stateless4j.triggers;
 
+import com.github.oxo42.stateless4j.delegates.Action;
 import com.github.oxo42.stateless4j.delegates.FuncBoolean;
 import com.github.oxo42.stateless4j.OutVar;
 
@@ -7,14 +8,20 @@ public abstract class TriggerBehaviour<S, T> {
 
     private final T trigger;
     private final FuncBoolean guard;
+    private final Action action;
 
-    protected TriggerBehaviour(T trigger, FuncBoolean guard) {
+    protected TriggerBehaviour(T trigger, FuncBoolean guard, Action action) {
         this.trigger = trigger;
         this.guard = guard;
+        this.action = action;
     }
 
     public T getTrigger() {
         return trigger;
+    }
+
+    public void performAction() {
+        action.doIt();
     }
 
     public boolean isGuardConditionMet() {

--- a/src/main/java/com/github/oxo42/stateless4j/triggers/TriggerBehaviour.java
+++ b/src/main/java/com/github/oxo42/stateless4j/triggers/TriggerBehaviour.java
@@ -1,6 +1,5 @@
 package com.github.oxo42.stateless4j.triggers;
 
-import com.github.oxo42.stateless4j.delegates.Action;
 import com.github.oxo42.stateless4j.delegates.FuncBoolean;
 import com.github.oxo42.stateless4j.OutVar;
 
@@ -8,21 +7,17 @@ public abstract class TriggerBehaviour<S, T> {
 
     private final T trigger;
     private final FuncBoolean guard;
-    private final Action action;
 
-    protected TriggerBehaviour(T trigger, FuncBoolean guard, Action action) {
+    protected TriggerBehaviour(T trigger, FuncBoolean guard) {
         this.trigger = trigger;
         this.guard = guard;
-        this.action = action;
     }
 
     public T getTrigger() {
         return trigger;
     }
 
-    public void performAction() {
-        action.doIt();
-    }
+    public abstract void performAction(Object[] args);
 
     public boolean isGuardConditionMet() {
         return guard.call();

--- a/src/test/java/com/github/oxo42/stateless4j/DynamicTransitionActionTests.java
+++ b/src/test/java/com/github/oxo42/stateless4j/DynamicTransitionActionTests.java
@@ -1,0 +1,184 @@
+package com.github.oxo42.stateless4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.github.oxo42.stateless4j.delegates.Action;
+import com.github.oxo42.stateless4j.delegates.Action1;
+import com.github.oxo42.stateless4j.delegates.Action2;
+import com.github.oxo42.stateless4j.delegates.Action3;
+import com.github.oxo42.stateless4j.delegates.Action4;
+import com.github.oxo42.stateless4j.delegates.Func;
+import com.github.oxo42.stateless4j.delegates.Func2;
+import com.github.oxo42.stateless4j.delegates.Func3;
+import com.github.oxo42.stateless4j.delegates.Func4;
+import com.github.oxo42.stateless4j.triggers.TriggerWithParameters1;
+import com.github.oxo42.stateless4j.triggers.TriggerWithParameters2;
+import com.github.oxo42.stateless4j.triggers.TriggerWithParameters3;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class DynamicTransitionActionTests {
+	
+    final Enum StateA = State.A, StateB = State.B, StateC = State.C,
+            TriggerX = Trigger.X, TriggerY = Trigger.Y;
+    
+    final private TriggerWithParameters1<Integer, State, Trigger> TriggerX1 =
+    		new TriggerWithParameters1<Integer, State, Trigger>(Trigger.X, Integer.class);
+    
+    final private TriggerWithParameters2<Integer, Integer, State, Trigger> TriggerY2 =
+    		new TriggerWithParameters2<Integer, Integer, State, Trigger>(Trigger.Y, Integer.class, Integer.class);
+    
+    final private TriggerWithParameters3<Integer, Integer, Integer, State, Trigger> TriggerY3 =
+    		new TriggerWithParameters3<Integer, Integer, Integer, State, Trigger>(Trigger.Y, Integer.class, Integer.class, Integer.class);
+
+    
+    private class DynamicallyGotoState<T> implements Func<State>, Func2<T, State>, Func3<T, T, State>, Func4<T, T, T, State> {
+
+    	private State targetState;
+    	
+    	public DynamicallyGotoState(State whereToGo) {
+    		this.targetState = whereToGo;
+    	}
+    	
+        @Override
+        public State call() {
+            return this.targetState;
+        }
+
+        @Override
+        public State call(T value) {
+            return this.targetState;
+        }
+
+        @Override
+        public State call(T val1, T val2) {
+            return this.targetState;
+        }
+
+        @Override
+        public State call(T val1, T val2, T val3) {
+            return this.targetState;
+        }
+    };
+    
+    private DynamicallyGotoState<Integer> gotoA = new DynamicallyGotoState<Integer>(State.A);
+    private DynamicallyGotoState<Integer> gotoB = new DynamicallyGotoState<Integer>(State.B);
+
+    private class AccumulatingAction<T> implements Action1<T>, Action2<T,T>, Action3<T,T,T>, Action4<T,T,T,T> {
+        private List<T> accumulator;
+
+        public AccumulatingAction(List<T> accumulator) {
+            this.accumulator = accumulator;
+        }
+
+		@Override
+		public void doIt(T arg1, T arg2, T arg3, T arg4) {
+        	accumulator.add(arg1);
+        	accumulator.add(arg2);
+        	accumulator.add(arg3);
+        	accumulator.add(arg4);	
+		}
+
+		@Override
+		public void doIt(T arg1, T arg2, T arg3) {
+        	accumulator.add(arg1);
+        	accumulator.add(arg2);
+        	accumulator.add(arg3);	
+		}
+
+		@Override
+		public void doIt(T arg1, T arg2) {
+        	accumulator.add(arg1);
+        	accumulator.add(arg2);
+		}
+
+		@Override
+		public void doIt(T arg1) {
+        	accumulator.add(arg1);
+		}
+    }
+    
+    private class FixedAccumulator<T> extends AccumulatingAction<T> implements Action {
+    	private T fixedItem;
+    	
+    	public FixedAccumulator(List<T> accumulator, T fixedItem) {
+    		super(accumulator);
+    		this.fixedItem = fixedItem;
+    	}
+    	
+    	@Override
+    	public void doIt() {
+    		doIt(this.fixedItem);
+    	}
+    }
+    
+    @Test
+    public void UnguardedDynamicTransitionActionsArePerformed() {
+        StateMachineConfig<State, Trigger> config = new StateMachineConfig<>();
+
+        List<Integer> list = new ArrayList<Integer>();
+        FixedAccumulator<Integer>   actionZero = new FixedAccumulator<Integer>(list, new Integer(0));
+        AccumulatingAction<Integer> actionOne = new AccumulatingAction<Integer>(list);
+        AccumulatingAction<Integer> actionTwo = new AccumulatingAction<Integer>(list);
+        AccumulatingAction<Integer> actionThree = new AccumulatingAction<Integer>(list);
+
+        config.configure(State.A)
+                .permitDynamic(Trigger.X, gotoB, actionZero)
+                .permitDynamic(TriggerY2, gotoB, actionTwo);
+        config.configure(State.B)
+        		.permitDynamic(TriggerX1, gotoA, actionOne)
+        		.permitDynamic(TriggerY3, gotoA, actionThree);
+
+        StateMachine<State, Trigger> sm = new StateMachine<>(State.A, config);
+        sm.fire(Trigger.X);
+        sm.fire(TriggerX1, new Integer(2));
+        sm.fire(TriggerY2, new Integer(4), new Integer(6));
+        sm.fire(TriggerY3, new Integer(8), new Integer(10), new Integer(12));
+
+        assertEquals(State.A, sm.getState());
+        assertEquals(7, list.size());
+        assertEquals(new Integer(0), list.get(0));
+        assertEquals(new Integer(2), list.get(1));
+        assertEquals(new Integer(4), list.get(2));
+        assertEquals(new Integer(6), list.get(3));
+        assertEquals(new Integer(8), list.get(4));
+        assertEquals(new Integer(10), list.get(5));
+        assertEquals(new Integer(12), list.get(6));
+    }
+
+    @Test
+    public void GuardedDynamicTransitionActionsArePerformed() {
+        StateMachineConfig<State, Trigger> config = new StateMachineConfig<>();
+
+        List<Integer> list = new ArrayList<Integer>();
+        FixedAccumulator<Integer>   actionZero = new FixedAccumulator<Integer>(list, new Integer(0));
+        AccumulatingAction<Integer> actionOne = new AccumulatingAction<Integer>(list);
+        AccumulatingAction<Integer> actionTwo = new AccumulatingAction<Integer>(list);
+        AccumulatingAction<Integer> actionThree = new AccumulatingAction<Integer>(list);
+
+        config.configure(State.A)
+                .permitDynamicIf(Trigger.X, gotoB, IgnoredTriggerBehaviourTests.returnTrue, actionZero)
+                .permitDynamicIf(TriggerY2, gotoB, IgnoredTriggerBehaviourTests.returnTrue, actionTwo);
+        config.configure(State.B)
+        		.permitDynamicIf(TriggerX1, gotoA, IgnoredTriggerBehaviourTests.returnTrue, actionOne)
+        		.permitDynamicIf(TriggerY3, gotoA, IgnoredTriggerBehaviourTests.returnTrue, actionThree);
+
+        StateMachine<State, Trigger> sm = new StateMachine<>(State.A, config);
+        sm.fire(Trigger.X);
+        sm.fire(TriggerX1, new Integer(3));
+        sm.fire(TriggerY2, new Integer(6), new Integer(9));
+        sm.fire(TriggerY3, new Integer(12), new Integer(15), new Integer(18));
+
+        assertEquals(State.A, sm.getState());
+        assertEquals(7, list.size());
+        assertEquals(new Integer(0), list.get(0));
+        assertEquals(new Integer(3), list.get(1));
+        assertEquals(new Integer(6), list.get(2));
+        assertEquals(new Integer(9), list.get(3));
+        assertEquals(new Integer(12), list.get(4));
+        assertEquals(new Integer(15), list.get(5));
+        assertEquals(new Integer(18), list.get(6));
+    }
+}

--- a/src/test/java/com/github/oxo42/stateless4j/IgnoredTriggerBehaviourTests.java
+++ b/src/test/java/com/github/oxo42/stateless4j/IgnoredTriggerBehaviourTests.java
@@ -36,25 +36,25 @@ public class IgnoredTriggerBehaviourTests {
 
     @Test
     public void StateRemainsUnchanged() {
-        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue, nopAction);
+        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue);
         assertFalse(ignored.resultsInTransitionFrom(State.B, new Object[0], new OutVar<State>()));
     }
 
     @Test
     public void ExposesCorrectUnderlyingTrigger() {
-        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue, nopAction);
+        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue);
         assertEquals(Trigger.X, ignored.getTrigger());
     }
 
     @Test
     public void WhenGuardConditionFalse_IsGuardConditionMetIsFalse() {
-        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnFalse, nopAction);
+        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnFalse);
         assertFalse(ignored.isGuardConditionMet());
     }
 
     @Test
     public void WhenGuardConditionTrue_IsGuardConditionMetIsTrue() {
-        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue, nopAction);
+        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue);
         assertTrue(ignored.isGuardConditionMet());
     }
 }

--- a/src/test/java/com/github/oxo42/stateless4j/IgnoredTriggerBehaviourTests.java
+++ b/src/test/java/com/github/oxo42/stateless4j/IgnoredTriggerBehaviourTests.java
@@ -1,5 +1,6 @@
 package com.github.oxo42.stateless4j;
 
+import com.github.oxo42.stateless4j.delegates.Action;
 import com.github.oxo42.stateless4j.delegates.FuncBoolean;
 import com.github.oxo42.stateless4j.triggers.IgnoredTriggerBehaviour;
 import org.junit.Test;
@@ -26,27 +27,34 @@ public class IgnoredTriggerBehaviourTests {
         }
     };
 
+    public static Action nopAction = new Action() {
+
+        @Override
+        public void doIt() {
+        }
+    };
+
     @Test
     public void StateRemainsUnchanged() {
-        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue);
+        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue, nopAction);
         assertFalse(ignored.resultsInTransitionFrom(State.B, new Object[0], new OutVar<State>()));
     }
 
     @Test
     public void ExposesCorrectUnderlyingTrigger() {
-        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue);
+        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue, nopAction);
         assertEquals(Trigger.X, ignored.getTrigger());
     }
 
     @Test
     public void WhenGuardConditionFalse_IsGuardConditionMetIsFalse() {
-        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnFalse);
+        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnFalse, nopAction);
         assertFalse(ignored.isGuardConditionMet());
     }
 
     @Test
     public void WhenGuardConditionTrue_IsGuardConditionMetIsTrue() {
-        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue);
+        IgnoredTriggerBehaviour<State, Trigger> ignored = new IgnoredTriggerBehaviour<>(Trigger.X, returnTrue, nopAction);
         assertTrue(ignored.isGuardConditionMet());
     }
 }

--- a/src/test/java/com/github/oxo42/stateless4j/StateRepresentationTests.java
+++ b/src/test/java/com/github/oxo42/stateless4j/StateRepresentationTests.java
@@ -320,7 +320,7 @@ public class StateRepresentationTests {
     public void WhenTransitionExistsButGuardConditionNotMet_TriggerCanBeFired() {
         StateRepresentation<State, Trigger> rep = CreateRepresentation(State.B);
         rep.addTriggerBehaviour(new IgnoredTriggerBehaviour<State, Trigger>(
-                Trigger.X, IgnoredTriggerBehaviourTests.returnFalse, IgnoredTriggerBehaviourTests.nopAction));
+                Trigger.X, IgnoredTriggerBehaviourTests.returnFalse));
         assertFalse(rep.canHandle(Trigger.X));
     }
 
@@ -328,7 +328,7 @@ public class StateRepresentationTests {
     public void WhenTransitionDoesNotExist_TriggerCannotBeFired() {
         StateRepresentation<State, Trigger> rep = CreateRepresentation(State.B);
         rep.addTriggerBehaviour(new IgnoredTriggerBehaviour<State, Trigger>(
-                Trigger.X, IgnoredTriggerBehaviourTests.returnTrue, IgnoredTriggerBehaviourTests.nopAction));
+                Trigger.X, IgnoredTriggerBehaviourTests.returnTrue));
         assertTrue(rep.canHandle(Trigger.X));
     }
 
@@ -336,7 +336,7 @@ public class StateRepresentationTests {
     public void WhenTransitionExistsInSupersate_TriggerCanBeFired() {
         StateRepresentation<State, Trigger> rep = CreateRepresentation(State.B);
         rep.addTriggerBehaviour(new IgnoredTriggerBehaviour<State, Trigger>(
-                Trigger.X, IgnoredTriggerBehaviourTests.returnTrue, IgnoredTriggerBehaviourTests.nopAction));
+                Trigger.X, IgnoredTriggerBehaviourTests.returnTrue));
         StateRepresentation<State, Trigger> sub = CreateRepresentation(State.C);
         sub.setSuperstate(rep);
         rep.addSubstate(sub);

--- a/src/test/java/com/github/oxo42/stateless4j/StateRepresentationTests.java
+++ b/src/test/java/com/github/oxo42/stateless4j/StateRepresentationTests.java
@@ -319,21 +319,24 @@ public class StateRepresentationTests {
     @Test
     public void WhenTransitionExistsButGuardConditionNotMet_TriggerCanBeFired() {
         StateRepresentation<State, Trigger> rep = CreateRepresentation(State.B);
-        rep.addTriggerBehaviour(new IgnoredTriggerBehaviour<State, Trigger>(Trigger.X, IgnoredTriggerBehaviourTests.returnFalse));
+        rep.addTriggerBehaviour(new IgnoredTriggerBehaviour<State, Trigger>(
+                Trigger.X, IgnoredTriggerBehaviourTests.returnFalse, IgnoredTriggerBehaviourTests.nopAction));
         assertFalse(rep.canHandle(Trigger.X));
     }
 
     @Test
     public void WhenTransitionDoesNotExist_TriggerCannotBeFired() {
         StateRepresentation<State, Trigger> rep = CreateRepresentation(State.B);
-        rep.addTriggerBehaviour(new IgnoredTriggerBehaviour<State, Trigger>(Trigger.X, IgnoredTriggerBehaviourTests.returnTrue));
+        rep.addTriggerBehaviour(new IgnoredTriggerBehaviour<State, Trigger>(
+                Trigger.X, IgnoredTriggerBehaviourTests.returnTrue, IgnoredTriggerBehaviourTests.nopAction));
         assertTrue(rep.canHandle(Trigger.X));
     }
 
     @Test
     public void WhenTransitionExistsInSupersate_TriggerCanBeFired() {
         StateRepresentation<State, Trigger> rep = CreateRepresentation(State.B);
-        rep.addTriggerBehaviour(new IgnoredTriggerBehaviour<State, Trigger>(Trigger.X, IgnoredTriggerBehaviourTests.returnTrue));
+        rep.addTriggerBehaviour(new IgnoredTriggerBehaviour<State, Trigger>(
+                Trigger.X, IgnoredTriggerBehaviourTests.returnTrue, IgnoredTriggerBehaviourTests.nopAction));
         StateRepresentation<State, Trigger> sub = CreateRepresentation(State.C);
         sub.setSuperstate(rep);
         rep.addSubstate(sub);

--- a/src/test/java/com/github/oxo42/stateless4j/TransitionActionTests.java
+++ b/src/test/java/com/github/oxo42/stateless4j/TransitionActionTests.java
@@ -1,0 +1,139 @@
+package com.github.oxo42.stateless4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import com.github.oxo42.stateless4j.delegates.Action;
+
+public class TransitionActionTests {
+
+    final Enum StateA = State.A, StateB = State.B, StateC = State.C,
+            TriggerX = Trigger.X, TriggerY = Trigger.Y;
+
+    private class TripwireAction implements Action {
+        private boolean beenThere;
+
+        public TripwireAction() {
+            beenThere = false;
+        }
+
+        public boolean wasPerformed() {
+            return beenThere;
+        }
+
+        @Override
+        public void doIt() {
+            beenThere = true;
+        }
+    }
+
+    private class CountingAction implements Action {
+        private List<Integer> numbers;
+        private Integer number;
+
+        public CountingAction(List<Integer> numbers, Integer number) {
+            this.numbers = numbers;
+            this.number = number;
+        }
+
+        @Override
+        public void doIt() {
+            numbers.add(this.number);
+        }
+    }
+
+    @Test
+    public void UnguardedActionIsPerformed() {
+        StateMachineConfig<State, Trigger> config = new StateMachineConfig<>();
+
+        TripwireAction action = new TripwireAction();
+
+        config.configure(State.A)
+                .permit(Trigger.Z, State.B, action);
+
+        StateMachine<State, Trigger> sm = new StateMachine<>(State.A, config);
+        sm.fire(Trigger.Z);
+
+        assertEquals(State.B, sm.getState());
+        assertTrue(action.wasPerformed());
+    }
+
+    @Test
+    public void TransitionActionIsPerformedBetweenExitAndEntry() {
+        StateMachineConfig<State, Trigger> config = new StateMachineConfig<>();
+
+        List<Integer> list = new ArrayList<Integer>();
+        Action exitAction = new CountingAction(list, new Integer(1));
+        Action transitionAction = new CountingAction(list, new Integer(2));
+        Action entryAction = new CountingAction(list, new Integer(3));
+
+        config.disableEntryActionOfInitialState();
+        config.configure(State.A)
+                .onExit(exitAction)
+                .permit(Trigger.Z, State.B, transitionAction);
+
+        config.configure(State.B)
+                .onEntry(entryAction);
+
+        StateMachine<State, Trigger> sm = new StateMachine<>(State.A, config);
+        sm.fire(Trigger.Z);
+
+        assertEquals(State.B, sm.getState());
+
+        assertEquals(3, list.size());
+        assertEquals(new Integer(1), list.get(0));
+        assertEquals(new Integer(2), list.get(1));
+        assertEquals(new Integer(3), list.get(2));
+    }
+
+    @Test
+    public void ActionWithPositiveGuardIsPerformed() {
+        StateMachineConfig<State, Trigger> config = new StateMachineConfig<>();
+
+        TripwireAction action = new TripwireAction();
+
+        config.configure(State.A)
+            .permitIf(Trigger.X, State.C, IgnoredTriggerBehaviourTests.returnTrue, action);
+
+        StateMachine<State, Trigger> sm = new StateMachine<>(State.A, config);
+        sm.fire(Trigger.X);
+
+        assertEquals(State.C, sm.getState());
+        assertTrue(action.wasPerformed());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void ActionWithNegativeGuardIsNotPerformed() {
+        StateMachineConfig<State, Trigger> config = new StateMachineConfig<>();
+
+        TripwireAction action = new TripwireAction();
+
+        config.configure(State.A)
+            .permitIf(Trigger.X, State.C, IgnoredTriggerBehaviourTests.returnFalse, action);
+
+        StateMachine<State, Trigger> sm = new StateMachine<>(State.A, config);
+        sm.fire(Trigger.X);
+    }
+
+    @Test
+    public void ActionWithCorrectGuardIsPerformed() {
+        StateMachineConfig<State, Trigger> config = new StateMachineConfig<>();
+
+        TripwireAction correctAction = new TripwireAction();
+        TripwireAction wrongAction = new TripwireAction();
+
+        config.configure(State.A)
+            .permitIf(Trigger.X, State.B, IgnoredTriggerBehaviourTests.returnFalse, wrongAction)
+            .permitIf(Trigger.X, State.C, IgnoredTriggerBehaviourTests.returnTrue, correctAction);
+
+        StateMachine<State, Trigger> sm = new StateMachine<>(State.A, config);
+        sm.fire(Trigger.X);
+
+        assertEquals(State.C, sm.getState());
+        assertTrue(correctAction.wasPerformed());
+        assertFalse(wrongAction.wasPerformed());
+    }
+}

--- a/src/test/java/com/github/oxo42/stateless4j/TransitioningTriggerBehaviourTests.java
+++ b/src/test/java/com/github/oxo42/stateless4j/TransitioningTriggerBehaviourTests.java
@@ -1,7 +1,6 @@
 package com.github.oxo42.stateless4j;
 
 import com.github.oxo42.stateless4j.transitions.TransitioningTriggerBehaviour;
-import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
@@ -10,7 +9,9 @@ public class TransitioningTriggerBehaviourTests {
 
     @Test
     public void TransitionsToDestinationState() {
-        TransitioningTriggerBehaviour<State, Trigger> transtioning = new TransitioningTriggerBehaviour<>(Trigger.X, State.C, IgnoredTriggerBehaviourTests.returnTrue);
+        TransitioningTriggerBehaviour<State, Trigger> transtioning =
+                new TransitioningTriggerBehaviour<>(Trigger.X, State.C,
+                        IgnoredTriggerBehaviourTests.returnTrue, IgnoredTriggerBehaviourTests.nopAction);
         OutVar<State> destination = new OutVar<>();
         assertTrue(transtioning.resultsInTransitionFrom(State.B, new Object[0], destination));
         assertEquals(State.C, destination.get());

--- a/src/test/java/com/github/oxo42/stateless4j/TriggerBehaviourTests.java
+++ b/src/test/java/com/github/oxo42/stateless4j/TriggerBehaviourTests.java
@@ -1,6 +1,5 @@
 package com.github.oxo42.stateless4j;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.github.oxo42.stateless4j.transitions.TransitioningTriggerBehaviour;
@@ -13,7 +12,7 @@ public class TriggerBehaviourTests {
     @Test
     public void ExposesCorrectUnderlyingTrigger() {
         TransitioningTriggerBehaviour<State, Trigger> transtioning = new TransitioningTriggerBehaviour<>(
-                Trigger.X, State.C, IgnoredTriggerBehaviourTests.returnTrue);
+                Trigger.X, State.C, IgnoredTriggerBehaviourTests.returnTrue, IgnoredTriggerBehaviourTests.nopAction);
 
         assertEquals(Trigger.X, transtioning.getTrigger());
     }
@@ -21,7 +20,7 @@ public class TriggerBehaviourTests {
     @Test
     public void WhenGuardConditionFalse_IsGuardConditionMetIsFalse() {
         TransitioningTriggerBehaviour<State, Trigger> transtioning = new TransitioningTriggerBehaviour<>(
-                Trigger.X, State.C, IgnoredTriggerBehaviourTests.returnFalse);
+                Trigger.X, State.C, IgnoredTriggerBehaviourTests.returnFalse, IgnoredTriggerBehaviourTests.nopAction);
 
         assertFalse(transtioning.isGuardConditionMet());
     }
@@ -29,7 +28,7 @@ public class TriggerBehaviourTests {
     @Test
     public void WhenGuardConditionTrue_IsGuardConditionMetIsTrue() {
         TransitioningTriggerBehaviour<State, Trigger> transtioning = new TransitioningTriggerBehaviour<>(
-                Trigger.X, State.C, IgnoredTriggerBehaviourTests.returnTrue);
+                Trigger.X, State.C, IgnoredTriggerBehaviourTests.returnTrue, IgnoredTriggerBehaviourTests.nopAction);
 
         assertTrue(transtioning.isGuardConditionMet());
     }


### PR DESCRIPTION
## Motivation

UML state machine describes a transition as:

```
            ---- event [ guard ] / action --->
```

Current implementation of stateless4j only supports actions on entry and
exit which is not the same.
## Modifications

This feature was implemented in three steps:
- Add actions to 'permit' and 'permitIf'
- Add actions to 'permitReentry' and 'permitReentryIf'
- Add actions to 'permitDynamic' and 'permitDynamicIf'

See the commit messages for details
## Result

One can add an action to a transition which is executed if this transition is taken.
In case of a dynamic transition, the action will receive the parameters of trigger.
